### PR TITLE
Improved various compatibility and support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.php]
+indent_size = 4
+
+[Makefile]
+indent_style = tab

--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
+APP_ENV=test
 KERNEL_CLASS=Tests\PantherActions\Kernel
 
 PANTHER_APP_ENV=panther

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,6 @@ jobs:
       fail-fast: false
       matrix:
         php:
-        - '7.4'
         - '8.0'
         - '8.1'
         deps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,30 +4,24 @@ name: Continuous Integration
 on:
   pull_request:
 
-env:
-  DOCKER_COMPOSE: docker-compose
-  DOCKER_BUILDKIT: 1
-  COMPOSE_DOCKER_CLI_BUILD: 1
-
 jobs:
-  init:
-    runs-on: ubuntu-latest
-    outputs:
-      application: ${{ steps.filter.outputs.application }}
-    steps:
-    - uses: styfle/cancel-workflow-action@0.9.1
-
-  checks:
+  test:
     timeout-minutes: 5
     runs-on: ubuntu-latest
-    needs: [init]
+    strategy:
+      fail-fast: false
+      matrix:
+        php:
+        - 8.0
+        - 8.1
+        deps:
+        - "--prefer-stable"
+        - "--prefer-lowest"
+    env:
+      PHP_VERSION: ${{ matrix.php }}
     steps:
     - uses: actions/checkout@v2.4.0
-    - uses: satackey/action-docker-layer-caching@v0.0.11
-      continue-on-error: true
-      with:
-        key: ${{ github.workflow }}-${{ hashFiles('Dockerfile') }}-{hash}
-        restore-keys: ${{ github.workflow }}-${{ hashFiles('Dockerfile') }}-
+    - uses: styfle/cancel-workflow-action@0.9.1
     - name: Setup Composer cache
       uses: actions/cache@v2.1.7
       with:
@@ -36,6 +30,11 @@ jobs:
           composer-${{ hashFiles('composer.json') }}
           composer-
     - run: make install
-    - run: make cs-check
-    - run: make phpstan
-    - run: make test
+    - name: Code style
+      if: ${{ matrix.php == '8.0' && matrix.deps == '--prefer-stable' }}
+      run: make cs-check
+    - name: Static analysis
+      if: ${{ matrix.php == '8.0' && matrix.deps == '--prefer-stable' }}
+      run: make phpstan
+    - name: Test suite
+      run: make test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         php:
+        - '7.4'
         - '8.0'
         - '8.1'
         deps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,10 @@ name: Continuous Integration
 on:
   pull_request:
 
+env:
+  DOCKER_BUILDKIT: 1
+  COMPOSE_DOCKER_CLI_BUILD: 1
+
 jobs:
   test:
     timeout-minutes: 5

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,8 +12,8 @@ jobs:
       fail-fast: false
       matrix:
         php:
-        - 8.0
-        - 8.1
+        - '8.0'
+        - '8.1'
         deps:
         - "--prefer-stable"
         - "--prefer-lowest"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 # base php image
-FROM php:8.0.13-fpm-alpine3.13 AS php
-COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
+FROM php:8.0-alpine AS php
 
 RUN apk add --no-cache git curl chromium chromium-chromedriver
 ENV COMPOSER_MEMORY_LIMIT -1
@@ -8,11 +7,4 @@ ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME /composer
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
-RUN install-php-extensions \
-      intl \
-      opcache \
-      pcntl \
-      zip \
-    ;
-RUN mv $PHP_INI_DIR/php.ini-development $PHP_INI_DIR/php.ini
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
-# base php image
-FROM php:8.0-alpine AS php
+ARG PHP_VERSION=8.0
+FROM php:${PHP_VERSION}-cli-alpine
+
+COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
+RUN install-php-extensions zip
 
 RUN apk add --no-cache git curl chromium chromium-chromedriver
 ENV COMPOSER_MEMORY_LIMIT -1

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
     "sort-packages": true
   },
   "require": {
-    "php": ">=7.4",
+    "php": ">=8.0",
     "ext-dom": "*",
     "ext-libxml": "*",
     "ext-zip": "*",
-    "symfony/panther": "^1.1 || ^2.0",
+    "symfony/panther": "^2.0",
     "phpunit/phpunit": "^9.5"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "php": ">=8.0",
     "ext-dom": "*",
     "ext-libxml": "*",
+    "ext-zip": "*",
     "symfony/panther": "^2.0",
     "phpunit/phpunit": "^9.5"
   },

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
   "require-dev": {
     "behat/behat": "^3.8",
     "pararius/cs": "^0.1.0",
+    "phpstan/extension-installer": "^1.1",
     "phpstan/phpstan": "^1.0",
     "phpstan/phpstan-phpunit": "^1.0",
     "symfony/dotenv": "^5.3 || ^6.0",

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
     "sort-packages": true
   },
   "require": {
-    "php": ">=8.0",
+    "php": ">=7.4",
     "ext-dom": "*",
     "ext-libxml": "*",
     "ext-zip": "*",
-    "symfony/panther": "^2.0",
+    "symfony/panther": "^1.1 || ^2.0",
     "phpunit/phpunit": "^9.5"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -15,20 +15,20 @@
     "sort-packages": true
   },
   "require": {
-    "php": ">=7.3",
+    "php": ">=8.0",
     "ext-dom": "*",
     "ext-libxml": "*",
-    "ext-zip": "*",
-    "symfony/panther": "^1.0.1",
+    "symfony/panther": "^2.0",
     "phpunit/phpunit": "^9.5"
   },
   "require-dev": {
     "behat/behat": "^3.8",
     "pararius/cs": "^0.1.0",
-    "phpstan/phpstan": "^0.12.90",
-    "symfony/dotenv": "^5.3",
-    "symfony/framework-bundle": "^5.3",
-    "symfony/security-core": "^5.3"
+    "phpstan/phpstan": "^1.0",
+    "phpstan/phpstan-phpunit": "^1.0",
+    "symfony/dotenv": "^5.3 || ^6.0",
+    "symfony/framework-bundle": "^5.3 || ^6.0",
+    "symfony/security-core": "^5.3 || ^6.0"
   },
   "autoload": {
     "psr-4": { "PantherActions\\": "src/" }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,36 +1,32 @@
 version: '3.7'
 
+x-php:
+  &php
+  build:
+    args:
+      PHP_VERSION: ${PHP_VERSION:-8.0}
+  env_file:
+  - .env
+  volumes:
+  - ./:/app:delegated
+  - ~/.composer/cache:/composer/cache:delegated
+  networks:
+  - panther
+
 services:
   php:
-    build:
-      context: .
-      target: php
-    env_file:
-      - .env
-    volumes:
-    - ./:/app:delegated
-    networks:
-    - test
+    <<: *php
 
   ready:
     image: jwilder/dockerize
     networks:
-    - test
+    - panther
 
   test-webserver:
-    build:
-      context: .
-      target: php
+    <<: *php
     command: [ "php", "-dvariables_order=EGPCS", "-S", "0.0.0.0:9080", "-t", "/app/tests/public" ]
-    environment:
-      APP_ENV: test
-    volumes:
-    - ./:/app:delegated
-    - ~/.composer/cache:/composer/cache:delegated
     ports:
     - "9080:9080"
-    networks:
-    - test
 
 networks:
-  test:
+  panther:

--- a/src/PantherActions.php
+++ b/src/PantherActions.php
@@ -205,7 +205,7 @@ trait PantherActions
                     $field->attr('name') => $value,
                 ])
             ;
-        } catch (InvalidArgumentException | NoSuchElementException $exception) {
+        } catch (InvalidArgumentException|NoSuchElementException $exception) {
             throw new RuntimeException(
                 "Could not fill form field \"{$fieldText}\"",
                 $exception->getCode(),

--- a/src/PantherActions.php
+++ b/src/PantherActions.php
@@ -1,7 +1,5 @@
 <?php
 
-/** @noinspection PhpMultipleClassDeclarationsInspection */
-
 declare(strict_types=1);
 
 namespace PantherActions;
@@ -9,7 +7,6 @@ namespace PantherActions;
 use Facebook\WebDriver\Exception\NoSuchElementException;
 use InvalidArgumentException;
 use PHPUnit\Framework\Assert;
-use PHPUnit\Framework\AssertionFailedError;
 use RuntimeException;
 use Symfony\Component\Panther\Client;
 use Symfony\Component\Panther\DomCrawler\Crawler;
@@ -260,7 +257,6 @@ trait PantherActions
     protected static function printCookies(): void
     {
         $client = self::client();
-        /** @noinspection ForgottenDebugOutputInspection */
         print_r($client->getCookieJar()->all());
     }
 

--- a/tests/PantherActionsTest.php
+++ b/tests/PantherActionsTest.php
@@ -1,10 +1,13 @@
 <?php
 
+/** @noinspection PhpMultipleClassDeclarationsInspection */
+
 declare(strict_types=1);
 
 namespace Tests\PantherActions;
 
 use PantherActions\PantherActions;
+use RuntimeException;
 use Symfony\Component\Panther\PantherTestCase;
 
 final class PantherActionsTest extends PantherTestCase
@@ -191,7 +194,7 @@ final class PantherActionsTest extends PantherTestCase
     }
 
     /** @test */
-    public function it_fills_a_textfield(): void
+    public function it_fills_a_textfield_by_label(): void
     {
         self::goTo('/form.html');
         self::assertCurrentAddressMatches('/form.html');
@@ -210,5 +213,26 @@ final class PantherActionsTest extends PantherTestCase
         $value = 'Value of the textfield';
         self::fillField('textfield with placeholder', $value);
         self::assertFormValue('form', 'placeholder', $value);
+    }
+
+    /** @test */
+    public function it_can_fill_a_field_by_nested_label(): void
+    {
+        self::goTo('/form-label-nested-text.html');
+
+        $value = 'Value of the textfield';
+        self::fillField('Textfield', $value);
+        self::assertFormValue('form', 'fld', $value);
+    }
+
+    /** @test */
+    public function it_cannot_fill_a_field_by_label_without_id(): void
+    {
+        self::goTo('/form-label-without-id.html');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Could not fill form field');
+
+        self::fillField('Textfield', 'foo');
     }
 }

--- a/tests/PantherActionsTest.php
+++ b/tests/PantherActionsTest.php
@@ -1,7 +1,5 @@
 <?php
 
-/** @noinspection PhpMultipleClassDeclarationsInspection */
-
 declare(strict_types=1);
 
 namespace Tests\PantherActions;

--- a/tests/public/form-label-nested-text.html
+++ b/tests/public/form-label-nested-text.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Index page</title>
+  </head>
+  <body>
+    <form>
+      <label for="fld">
+        <input type="text" name="fld" id="fld">
+        <span class="label">Textfield</span>
+      </label>
+    </form>
+  </body>
+</html>

--- a/tests/public/form-label-without-id.html
+++ b/tests/public/form-label-without-id.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Index page</title>
+  </head>
+  <body>
+    <form>
+      <label>
+        Textfield
+        <input type="text" name="fld">
+      </label>
+    </form>
+  </body>
+</html>


### PR DESCRIPTION
Upgraded Panther to 2.0. It should be mostly backwards compatible, according to the [readme](https://github.com/symfony/panther/blob/main/CHANGELOG.md#200)), only it raises the minimum PHP level to 8.0. I don't think this is a problem, since we also require `pararius/cs`, which also requires 8.0. Because we didn't test different PHP versions before, I think this went unnoticed.

So, because of this, the fact we're not yet at 1.0, and PHP 7.4 already [doesn't have active support anymore](https://www.php.net/supported-versions.php), I think we can safely raise the minimum version to 8.0 without disrupting anyone.

* Increased supported versions of Symfony (5.4 and 6.0)
* Added test matrix for CI
* Added editorconfig
* Added ability to override client options
* Fixed selecting a form field by label with nested text