### PR TITLE
Fixed firing change event on filling input

### DIFF
--- a/src/PantherActions.php
+++ b/src/PantherActions.php
@@ -200,11 +200,21 @@ trait PantherActions
     protected static function fillField(string $fieldText, string $value, string $legend = null, string $contextSelector = null): void
     {
         $field = self::findFormField($fieldText, $legend, $contextSelector);
+
+        $node = $field->nodeName();
+        $name = $field->attr('name');
+
+        // First clear the text, without firing a change event. This prevents such an event being fired when Panther
+        // clears the element before sending the keystrokes to update the value.
+        self::client()->executeScript(
+            <<<JS
+                document.querySelector('{$node}[name="{$name}"]').value = ''
+                JS
+        );
+
         $field
             ->filterXPath('ancestor::form')
-            ->form([
-                $field->attr('name') => $value,
-            ])
+            ->form([$name => $value])
         ;
     }
 

--- a/tests/PantherActionsTest.php
+++ b/tests/PantherActionsTest.php
@@ -275,4 +275,18 @@ final class PantherActionsTest extends PantherTestCase
         $field = self::findFormField('fld1', 'Legendary', '#nested-structure');
         self::assertSame('fld-with-fieldset-2', $field->attr('id'));
     }
+
+    /** @test */
+    public function it_does_not_fire_change_event_when_filling_form_field(): void
+    {
+        self::goTo('/form-input-change-event.html');
+
+        self::assertFormValue('form', 'fld1', 'Initial text');
+        self::fillField('fld1', 'Updated text');
+        self::assertFormValue('form', 'fld1', 'Updated text');
+
+        self::assertFormValue('form', 'fld2', 'Initial text');
+        self::fillField('fld2', 'Updated text');
+        self::assertFormValue('form', 'fld2', 'Updated text');
+    }
 }

--- a/tests/public/form-input-change-event.html
+++ b/tests/public/form-input-change-event.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Test page</title>
+  </head>
+  <body>
+    <form>
+      <label>
+        Text input
+        <input type="text" name="fld1" class="input" value="Initial text">
+      </label>
+      <label>
+        Textarea input
+        <textarea name="fld2" class="input">Initial text</textarea>
+      </label>
+    </form>
+  </body>
+  <script>
+    document.querySelectorAll('.input').forEach(input => {
+      input.addEventListener('change', () => input.value = 'changed!')
+    });
+  </script>
+</html>


### PR DESCRIPTION
When filling an `input` form field, Panther first clears the field, then sends the keystrokes for the new value. The problem is that clearing the field fires a `change` event, potentially triggering event listeners that you'd only want to trigger after the new value was entered.

This PR clears the element first, using javascript, so it does not fire that event.